### PR TITLE
Broken by npm v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,25 @@
 {
   "name": "no-broken-dependency-action-test",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "clsx": "^1.1.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.0.tgz",
+      "integrity": "sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA==",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
   "dependencies": {
     "clsx": {
       "version": "1.1.0",


### PR DESCRIPTION
This PR includes incorrect `package-lock.json`.
Please use npm v6 instead of v7 in this project.
Or, this CI will pass by inserting `npm i -g npm@7` step.
